### PR TITLE
fixed trackEvent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ A value can be passed for events:
 
 ```dart
 MatomoTracker.instance.trackEvent(
-    name: 'eventName',
+    eventCategory: 'eventCategory',
+    eventName: 'eventName',
     action: 'eventAction',
     eventValue: 18,
 );


### PR DESCRIPTION
In the current version 1.2.1, the `name` property is deprecated in favour of eventName, and also eventCategory is now required. Reflecting these changes in the README.